### PR TITLE
Update release version to 2.0.1

### DIFF
--- a/release/build.gradle
+++ b/release/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 	}
   }
   dependencies {
-    classpath group: 'jaci.openrio.gradle', name: 'GradleRIO', version: '1.3.0'			//Change this line if you wish to Update GradleRIO
+    classpath group: 'jaci.openrio.gradle', name: 'GradleRIO', version: '2.01'			//Change this line if you wish to Update GradleRIO
   }
 }
 


### PR DESCRIPTION
Old version number in build.gradle (1.15) not existing causes the script to fail, which might inhibit people who are new to gradle from using this (awesome) build system.