### PR TITLE
Updated the MDNS name for 2016

### DIFF
--- a/src/main/groovy/jaci/openrio/gradle/GradleRIO.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/GradleRIO.groovy
@@ -218,7 +218,7 @@ class GradleRIO implements Plugin<Project> {
   }
 
   static String rioHost(Project project) {
-    return "roboRIO-${project.gradlerio.team}.local"
+    return "roboRIO-${project.gradlerio.team}-frc.local"
   }
 
   static String team(Project project) {


### PR DESCRIPTION
This updates the MDNS name for the new scheme being used in 2016. The name was changed to roborio-number-frc.local to prevent MDNS number incrementing issues. Basically, when MDNS detects conflicts, it will append a number to the end and increment it. So in previous years, roborio-190.local would become roborio-191.local, then roborio-192.local, and so on. Now, it will start as roborio-190-frc.local, then go to roborio-190-frc-1.local, and so on.