### PR TITLE
Removed invalid arguments

### DIFF
--- a/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
@@ -60,15 +60,6 @@ class WPIRoboRioGcc extends CrossGcc {
                     target.cppCompiler.withArguments { a ->
                         a << '--sysroot' << sysroot
                     }
-                    target.linker.withArguments { a ->
-                        a << '--sysroot' << sysroot
-                    }
-                    target.assembler.withArguments { a ->
-                        a << '--sysroot' << sysroot
-                    }
-                    target.staticLibArchiver.withArguments { a ->
-                        a << '--sysroot' << sysroot
-                    }
                 }
 
                 target.cppCompiler.withArguments { a ->

--- a/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
@@ -60,6 +60,9 @@ class WPIRoboRioGcc extends CrossGcc {
                     target.cppCompiler.withArguments { a ->
                         a << '--sysroot' << sysroot
                     }
+                    target.linker.withArguments { a ->
+		-               a << '--sysroot' << sysroot
+                    }
                 }
 
                 target.cppCompiler.withArguments { a ->


### PR DESCRIPTION
--sysroot is not a valid argument for GCC's linker, assembler, or static archiver.

This should fix issue #52, though this is untested