### PR TITLE
A set of changes to enable the simulation targets

### DIFF
--- a/src/main/groovy/jaci/openrio/gradle/ExternalLaunchTask.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/ExternalLaunchTask.groovy
@@ -13,6 +13,7 @@ class ExternalLaunchTask extends DefaultTask {
     private def _withBuilderClosures = [] as List<Closure>
     def environment = [:] as Map<String, String>
     def persist = false
+    def headless = project.hasProperty('headless')
     def workingDir = null as File
 
     Process launch(String... cmd) {
@@ -63,7 +64,7 @@ class ExternalLaunchTask extends DefaultTask {
             }
         }
 
-        if (project.hasProperty('headless')) {
+        if (headless) {
             println "Commands written to ${file.absolutePath}! Run this file."
             return null;
         } else {

--- a/src/main/groovy/jaci/openrio/gradle/sim/JavaSimulationTask.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/sim/JavaSimulationTask.groovy
@@ -64,8 +64,8 @@ class JavaSimulationTask extends ExternalLaunchTask {
             environment["PATH"] = ldpath + ";" + System.getenv("PATH")
         }
         persist = true  // So if we crash instantly you can still see the output
-        //launch(java, "-Djava.library.path=${ldpath}", "-jar", jar.archivePath.toString())
+        headless = true
+        launch(java, "-Djava.library.path=${ldpath}", "-jar", jar.archivePath.toString())
         // TODO: Add some kind of subsystem here so we can launch externally. It should watch for a stopped build or something
-        println "Simulation is not yet implemented!"
     }
 }

--- a/src/main/groovy/jaci/openrio/gradle/sim/NativeSimulationTask.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/sim/NativeSimulationTask.groovy
@@ -22,9 +22,6 @@ class NativeSimulationTask extends ExternalLaunchTask {
 
     @TaskAction
     void run() {
-        // TODO: Spawn in new window (gradle daemon keeps this process alive)
-        // OR: Write a script that does this for the user?
-        //          i.e. task outputs a runnable file that the user then uses.
         def installTask = binary.tasks.withType(InstallExecutable).first()
         def env = SimulationPlugin.getHALExtensionsEnvVar(project)
         println "Using Environment: HALSIM_EXTENSIONS=${env}"
@@ -37,9 +34,9 @@ class NativeSimulationTask extends ExternalLaunchTask {
         }
         workingDir = installTask.installDirectory.asFile.get()
         persist = true
-        //launch(new File(dir, installTask.sourceFile.asFile.get().name).absolutePath)
+        headless = true
+        launch(new File(dir, installTask.sourceFile.asFile.get().name).absolutePath)
         // TODO: Add some kind of subsystem here so we can launch externally. It should watch for a stopped build or something
-        println "Simulation is not yet implemented!"
     }
 
 }

--- a/src/main/groovy/jaci/openrio/gradle/wpi/dependencies/WPICommonDeps.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/wpi/dependencies/WPICommonDeps.groovy
@@ -46,7 +46,7 @@ class WPICommonDeps implements Plugin<Project> {
                     ["edu.wpi.first.halsim:halsim-print:${wpi.wpilibVersion}:${native64classifier}@zip"]
                 },
                 nt_ds: {
-                    ["edu.wpi.first.halsim:halsim-ds-nt:${wpi.wpilibVersion}:${native64classifier}@zip"]
+                    ["edu.wpi.first.halsim.ds:halsim-ds-nt:${wpi.wpilibVersion}:${native64classifier}@zip"]
                 },
                 nt_readout: {
                     ["edu.wpi.first.halsim:halsim-lowfi:${wpi.wpilibVersion}:${native64classifier}@zip"]


### PR DESCRIPTION
With these 3 patches, and a modestly hacked _localtest, I am able to generate scripts on Linux to start the native simulation test. 