### PR TITLE
Add capabilities to make local publishing easier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,12 @@ pluginBundle {
 publishing {
     publications {
         plugin(MavenPublication) {
-            artifact jar
+            artifact(jar) {
+                if (project.hasProperty('localPublish')) {
+                    classifier null
+                    groupId 'gradle.plugin.' + group
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
If `-PlocalPublish` is set, and `publishToMavenLocal` is ran, then the group id's get set up properly to allow directly using the locally published artifact from a regular gradle project just updating the version. No need to set up the classpath differently for the plugin. There is no automated way to set localPublish when publishToMavenLocal is ran, so it has to be added manually.