### PR TITLE
Edit frcRunRobot.sh to remove "exec"

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
@@ -45,6 +45,7 @@ public class RoboRIO extends WPIRemoteTarget {
 
         programKillArtifact = project.getObjects().newInstance(MultiCommandArtifact.class, "programKill" + name, this);
         programKillArtifact.getExtensionContainer().add(DeployStage.class, "stage", DeployStage.ProgramKill);
+        programKillArtifact.addCommand("frcRunRobot", "sed -i -e 's/\"exec /\"/' /usr/local/bin/frc/frcRunRobot.sh");
         programKillArtifact.addCommand("kill", ". /etc/profile.d/natinst-path.sh; /usr/local/frc/bin/frcKillRobot.sh -t 2> /dev/null");
         programKillArtifact.addCommand("freemem", "sed -i -e 's/^StartupDLLs/;StartupDLLs/' /etc/natinst/share/ni-rt.ini");
 


### PR DESCRIPTION
This works around an issue in the 2022.2.2 (beta) image that prevents
C++/Java programs from successfully executing.