### PR TITLE
Adapt image regex for RIO2

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
@@ -141,7 +141,7 @@ public class RoboRIO extends WPIRemoteTarget {
 
     private void readAndVerifyImage(DeployContext context) {
         final String imageFile = "/etc/natinst/share/scs_imagemetadata.ini";
-        final Pattern pattern = Pattern.compile("^IMAGEVERSION\\s*=\\s*\\\"FRC_roboRIO(?:2)?_(\\d{4}_v\\d+(?:\\.\\d+)?)\\\"");
+        final Pattern pattern = Pattern.compile("^IMAGEVERSION\\s*=\\s*\\\"FRC_roboRIO2?_(\\d{4}_v\\d+(?:\\.\\d+)?)\\\"");
 
         String content = context.execute("cat " + imageFile).getResult();
         log.info("Received Image File: ");


### PR DESCRIPTION
Fixes #536 

I assume that the images for the RIO (1) are still named `FRC_roboRIO_YEAR...` without the 2?