### PR TITLE
Prepend to the system search path instead of overriding it

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
@@ -32,7 +32,7 @@ public class TestTaskDoFirstAction implements Action<Task> {
             env.put("DYLD_FALLBACK_LIBRARY_PATH", getPath("DYLD_FALLBACK_LIBRARY_PATH", ldpath));
             env.put("DYLD_LIBRARY_PATH", getPath("DYLD_LIBRARY_PATH", ldpath));
         } else if (OperatingSystem.current().isWindows()) {
-            env.put("PATH", System.getenv("PATH") + File.pathSeparator + ldpath);
+            env.put("PATH", getPath("PATH", ldpath));
         }
 
         t.environment(env);

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
@@ -28,11 +28,11 @@ public class TestTaskDoFirstAction implements Action<Task> {
         String ldpath = extract.get().get().getAsFile().getAbsolutePath();
 
         if (OperatingSystem.current().isUnix()) {
-            env.put("LD_LIBRARY_PATH", getPath("LD_LIBRARY_PATH", ldpath));
-            env.put("DYLD_FALLBACK_LIBRARY_PATH", getPath("DYLD_FALLBACK_LIBRARY_PATH", ldpath));
-            env.put("DYLD_LIBRARY_PATH", getPath("DYLD_LIBRARY_PATH", ldpath));
+            appendPath(env, "LD_LIBRARY_PATH", ldpath);
+            appendPath(env, "DYLD_FALLBACK_LIBRARY_PATH", ldpath);
+            appendPath(env, "DYLD_LIBRARY_PATH", ldpath);
         } else if (OperatingSystem.current().isWindows()) {
-            env.put("PATH", getPath("PATH", ldpath));
+            appendPath(env, "PATH", ldpath);
         }
 
         t.environment(env);
@@ -46,12 +46,12 @@ public class TestTaskDoFirstAction implements Action<Task> {
 
     }
 
-    private static String getPath(String envName, String ldpath) {
+    private static void appendPath(Map<String, String> env, String envName, String ldpath) {
         String currentPath = System.getenv(envName);
         if (currentPath != null) {
-            return currentPath + File.pathSeparator + ldpath;
+            env.put(envName, currentPath + File.pathSeparator + ldpath);
+        } else {
+            env.put(envName, ldpath);
         }
-        return ldpath;
     }
-
 }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
@@ -28,9 +28,9 @@ public class TestTaskDoFirstAction implements Action<Task> {
         String ldpath = extract.get().get().getAsFile().getAbsolutePath();
 
         if (OperatingSystem.current().isUnix()) {
-            env.put("LD_LIBRARY_PATH", ldpath);
-            env.put("DYLD_FALLBACK_LIBRARY_PATH", ldpath);
-            env.put("DYLD_LIBRARY_PATH", ldpath);
+            env.put("LD_LIBRARY_PATH", getPath("LD_LIBRARY_PATH", ldpath));
+            env.put("DYLD_FALLBACK_LIBRARY_PATH", getPath("DYLD_FALLBACK_LIBRARY_PATH", ldpath));
+            env.put("DYLD_LIBRARY_PATH", getPath("DYLD_LIBRARY_PATH", ldpath));
         } else if (OperatingSystem.current().isWindows()) {
             env.put("PATH", System.getenv("PATH") + File.pathSeparator + ldpath);
         }
@@ -44,6 +44,14 @@ public class TestTaskDoFirstAction implements Action<Task> {
         }
         t.getSystemProperties().put("java.library.path", jlp);
 
+    }
+
+    private static String getPath(String env, String ldpath) {
+        String currentPath = System.getenv(env);
+        if (currentPath != null) {
+            return currentPath + File.pathSeparator + ldpath;
+        }
+        return ldpath;
     }
 
 }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
@@ -46,8 +46,8 @@ public class TestTaskDoFirstAction implements Action<Task> {
 
     }
 
-    private static String getPath(String env, String ldpath) {
-        String currentPath = System.getenv(env);
+    private static String getPath(String envName, String ldpath) {
+        String currentPath = System.getenv(envName);
         if (currentPath != null) {
             return currentPath + File.pathSeparator + ldpath;
         }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/java/TestTaskDoFirstAction.java
@@ -49,7 +49,7 @@ public class TestTaskDoFirstAction implements Action<Task> {
     private static void appendPath(Map<String, String> env, String envName, String ldpath) {
         String currentPath = System.getenv(envName);
         if (currentPath != null) {
-            env.put(envName, currentPath + File.pathSeparator + ldpath);
+            env.put(envName, ldpath + File.pathSeparator + currentPath);
         } else {
             env.put(envName, ldpath);
         }


### PR DESCRIPTION
* Prepend the `ldpath` to `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, and `DYLD_FALLBACK_LIBRARY_PATH`
* Don't put the original environment variable in the new one if the environment variable is not set
  * To ensure that the path environment variable doesn't contain `null` if the environment variable wasn't set