### PR TITLE
Add MrcLib support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
   test_examples:
     needs: build
     runs-on: ubuntu-24.04
+    container: wpilib/debian-base:trixie
     strategy:
      matrix:
         language: [cpp, java] #, asm, jni]

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ bin/
 out/
 hs_err_*
 .vscode/
+networktables.json
+simgui-ds.json
+simgui-window.json
+simgui.json

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ configurations {
     processstarterDownload
 }
 
-def processstarterToolVersion = "2027.0.0-alpha-6"
+def processstarterToolVersion = "2027.0.0-alpha-6-68-g5a7d7d50e"
 
 dependencies {
     api 'com.google.code.gson:gson:2.13.1'
 
-    api 'org.wpilib:native-utils:2027.7.1'
+    api 'org.wpilib:native-utils:2027.9.0'
 
     api 'de.undercouch:gradle-download-task:5.6.0'
 

--- a/src/main/java/org/wpilib/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/WPIMavenExtension.java
@@ -29,7 +29,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         super(WPIMavenRepo.class, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP);
         this.project = project;
 
-        this.useDevelopment = false; // Do not rename without changing versionupdates.gradle
+        this.useDevelopment = true; // Do not rename without changing versionupdates.gradle
         this.useLocal = true;
         this.useWpilibMavenLocalDevelopment = false;
         this.useWpilibMavenLocalRelease = false;

--- a/src/main/java/org/wpilib/gradlerio/wpi/WPIVersionsExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/WPIVersionsExtension.java
@@ -6,18 +6,19 @@ import org.gradle.api.provider.Property;
 
 public abstract class WPIVersionsExtension {
 
-    private static final String wpilibVersion = "2027.0.0-alpha-6";
+    private static final String wpilibVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
     private static final String opencvVersion = "2027-4.13.0-3";
     private static final String avajeVersion = "3.14";
     private static final String ejmlVersion = "0.44.0";
     private static final String quickbufVersion = "1.4";
 
-    private static final String outlineViewerVersion = "2027.0.0-alpha-6";
-    private static final String glassVersion = "2027.0.0-alpha-6";
-    private static final String sysIdVersion = "2027.0.0-alpha-6";
-    private static final String dataLogToolVersion = "2027.0.0-alpha-6";
-    private static final String wpicalToolVersion = "2027.0.0-alpha-6";
-    private static final String processstarterToolVersion = "2027.0.0-alpha-6";
+    private static final String outlineViewerVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String glassVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String sysIdVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String dataLogToolVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String wpicalToolVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String processstarterToolVersion = "2027.0.0-alpha-6-68-g5a7d7d50e";
+    private static final String mrcLibVersion = "2027.1.0-alpha-1-65-g21f308e";
 
     public abstract Property<String> getWpilibVersion();
     public abstract Property<String> getOpencvVersion();
@@ -31,6 +32,7 @@ public abstract class WPIVersionsExtension {
     public abstract Property<String> getDataLogToolVersion();
     public abstract Property<String> getWpicalToolVersion();
     public abstract Property<String> getProcessstarterToolVersion();
+    public abstract Property<String> getMrcLibVersion();
 
     @Inject
     public WPIVersionsExtension() {
@@ -46,6 +48,7 @@ public abstract class WPIVersionsExtension {
         getDataLogToolVersion().convention(dataLogToolVersion);
         getWpicalToolVersion().convention(wpicalToolVersion);
         getProcessstarterToolVersion().convention(processstarterToolVersion);
+        getMrcLibVersion().convention(mrcLibVersion);
     }
 
 }

--- a/src/main/java/org/wpilib/gradlerio/wpi/cpp/WPINativeExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/cpp/WPINativeExtension.java
@@ -119,6 +119,7 @@ public class WPINativeExtension {
         nte.getWpi().configureDependencies(wpiDeps -> {
             wpiDeps.getWpiVersion().set(versions.getWpilibVersion());
             wpiDeps.getOpencvVersion().set(versions.getOpencvVersion());
+            wpiDeps.getMrcLibVersion().set(versions.getMrcLibVersion());
         });
 
         simulationTaskRelease = project.getTasks().register("simulateNativeRelease", NativeSimulationTask.class);

--- a/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaDepsExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaDepsExtension.java
@@ -103,7 +103,8 @@ public class WPIJavaDepsExtension {
             createJniDependency("org.wpilib.wpinet", "wpinet-cpp", versions.getWpilibVersion(), debug, platform),
             createJniDependency("org.wpilib.wpiutil", "wpiutil-cpp", versions.getWpilibVersion(), debug, platform),
             createJniDependency("org.wpilib.apriltag", "apriltag-cpp", versions.getWpilibVersion(), debug, platform),
-            createJniDependency("org.wpilib.datalog", "datalog-cpp", versions.getWpilibVersion(), debug, platform)
+            createJniDependency("org.wpilib.datalog", "datalog-cpp", versions.getWpilibVersion(), debug, platform),
+            createJniDependency("org.wpilib.mrclib", "mrclib-cpp", versions.getMrcLibVersion(), false, platform) // Does not have debug in any case
         );
     }
 }

--- a/testing/java/build.gradle
+++ b/testing/java/build.gradle
@@ -11,8 +11,8 @@ if (testingFolder.name != 'testing' || projectFolder.name != 'java') {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 def ROBOT_MAIN_CLASS = "first.team0000.robot.Main"

--- a/versionupdates.gradle
+++ b/versionupdates.gradle
@@ -8,17 +8,24 @@ def versionMap = [
   opencvVersion: 'org.wpilib.thirdparty.opencv:opencv-java:+',
   wpicalToolVersion: 'org.wpilib.tools:wpical:+:windowsx86-64@zip',
   processstarterToolVersion: 'org.wpilib.tools:processstarter:+:windowsx86-64@zip',
+  mrclibVersion: 'org.wpilib.mrclib:mrclib-cpp:+:windowsx86-64@zip',
 ]
 
 configurations {
   gradleRioVersions
 }
 
-def useDevelopmentProperty = 'useDevelopment'
+// We need some special logic to switch the processstarter tool between development and release repositories
+def currentUseDevelopment = true
+
+def switchToDevelopment = 'switchToDevelopment'
+def switchToRelease = 'switchToRelease'
+
+def useDevelopment = project.hasProperty(switchToDevelopment) || (currentUseDevelopment && !project.hasProperty(switchToRelease))
 
 project.repositories.maven { repo ->
     repo.name = "WPI"
-    if (project.hasProperty(useDevelopmentProperty)) {
+    if (useDevelopment) {
       repo.url = "https://frcmaven.wpi.edu/artifactory/development-2027"
     } else {
       repo.url = "https://frcmaven.wpi.edu/artifactory/release-2027"
@@ -35,17 +42,28 @@ String regex = "String\\s+?placeholder\\s+?=\\s+?[\\\"|\\'].+?[\\\"|\\']"
 String buildRegex = "def\\s+?placeholder\\s+?=\\s+?[\\\"|\\'].+?[\\\"|\\']"
 String mavenDevRegex = "this\\.useDevelopment\\s*=\\s*(true|false)"
 String validVersionsRegex = "validImageVersions = List\\.of\\((.+)\\);"
+String currentUseDevelopmentRegex = "def currentUseDevelopment\\s*=\\s*(true|false)"
 
 tasks.register('UpdateVersions') {
   doLast {
     def mavenExtFile = file('src/main/java/org/wpilib/gradlerio/wpi/WPIMavenExtension.java')
     def mavenExtText = mavenExtFile.text
     def toSet = "this.useDevelopment = false"
-    if (project.hasProperty(useDevelopmentProperty)) {
+    if (useDevelopment) {
       toSet = "this.useDevelopment = true"
     }
 
     mavenExtFile.text = mavenExtText.replaceAll(mavenDevRegex, toSet)
+
+    def thisFile = file('versionupdates.gradle')
+    def gradleToSet = "def currentUseDevelopment"
+
+    if (useDevelopment) {
+      gradleToSet += " = true"
+    } else {
+      gradleToSet += " = false"
+    }
+    thisFile.text = thisFile.text.replaceAll(currentUseDevelopmentRegex, gradleToSet)
 
 
     def extFile = file('src/main/java/org/wpilib/gradlerio/wpi/WPIVersionsExtension.java')

--- a/versionupdates.gradle
+++ b/versionupdates.gradle
@@ -8,7 +8,7 @@ def versionMap = [
   opencvVersion: 'org.wpilib.thirdparty.opencv:opencv-java:+',
   wpicalToolVersion: 'org.wpilib.tools:wpical:+:windowsx86-64@zip',
   processstarterToolVersion: 'org.wpilib.tools:processstarter:+:windowsx86-64@zip',
-  mrclibVersion: 'org.wpilib.mrclib:mrclib-cpp:+:windowsx86-64@zip',
+  mrcLibVersion: 'org.wpilib.mrclib:mrclib-cpp:+:windowsx86-64@zip',
 ]
 
 configurations {


### PR DESCRIPTION
Required a few other changes to make work. Mainly, since processtarter is grabbed during the build, we needed a way to store development vs release in the actual build script. So the way to change from development to release is different. 